### PR TITLE
fix missing thrift host, use local modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -94,3 +94,9 @@ require (
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
 	willnorris.com/go/imageproxy v0.9.0
 )
+
+// fix missing thrift host
+replace git.apache.org/thrift.git => github.com/apache/thrift v0.0.0-20180902110319-2566ecd5d999
+
+// use local modules
+replace github.com/cld9x/xbvr/pkg/xbvr => ./pkg/xbvr


### PR DESCRIPTION
Apache thrift dependency can't be fetched since git.apache.org is dead, it's now on github.
Also I guess using the rename command in go.mod would enable to use local packags.