### PR TITLE
Add RealityLovers and RealJamVR scrapers

### DIFF
--- a/pkg/scrape/realitylovers.go
+++ b/pkg/scrape/realitylovers.go
@@ -1,0 +1,129 @@
+package scrape
+
+import (
+	"log"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/gocolly/colly"
+	"github.com/mozillazg/go-slugify"
+	"github.com/thoas/go-funk"
+	"github.com/tidwall/gjson"
+	"gopkg.in/resty.v1"
+)
+
+func ScrapeRealityLovers(knownScenes []string, out *[]ScrapedScene) error {
+	const maxRetries = 15
+
+	sceneCollector := colly.NewCollector(
+		colly.AllowedDomains("realitylovers.com"),
+		colly.CacheDir(sceneCacheDir),
+		colly.UserAgent(userAgent),
+	)
+
+	sceneCollector.OnRequest(func(r *colly.Request) {
+		attempt := r.Ctx.GetAny("attempt")
+
+		if attempt == nil {
+			r.Ctx.Put("attempt", 1)
+		}
+
+		log.Println("visiting", r.URL.String())
+	})
+
+	sceneCollector.OnError(func(r *colly.Response, err error) {
+		attempt := r.Ctx.GetAny("attempt").(int)
+
+		if r.StatusCode == 429 {
+			log.Println("Error:", r.StatusCode, err)
+
+			if attempt <= maxRetries {
+				unCache(r.Request.URL.String(), sceneCollector.CacheDir)
+				log.Println("Waiting 2 seconds before next request...")
+				r.Ctx.Put("attempt", attempt+1)
+				time.Sleep(2 * time.Second)
+				r.Request.Retry()
+			}
+		}
+	})
+
+	sceneCollector.OnHTML(`html`, func(e *colly.HTMLElement) {
+		sc := ScrapedScene{}
+		sc.SceneType = "VR"
+		sc.Studio = "RealityLovers"
+		sc.Site = "RealityLovers"
+		sc.HomepageURL = strings.Split(e.Request.URL.String(), "?")[0]
+
+		// Scene ID
+		sc.SiteID = e.Request.Ctx.Get("id")
+		sc.SceneID = slugify.Slugify(sc.Site) + "-" + sc.SiteID
+
+		// Cover
+		sc.Covers = append(sc.Covers, e.Request.Ctx.Get("cover"))
+
+		// Title
+		sc.Title = e.Request.Ctx.Get("title")
+
+		// Release date
+		sc.Released = e.Request.Ctx.Get("released")
+
+		// Cast
+		e.ForEach(`a[itemprop="actor"]`, func(id int, e *colly.HTMLElement) {
+			sc.Cast = append(sc.Cast, strings.TrimSpace(e.Text))
+		})
+
+		// Gallery
+		e.ForEach(`img.videoClip__Details--galleryItem`, func(id int, e *colly.HTMLElement) {
+			imageURL := strings.Fields(e.Attr("data-big"))[0]
+			sc.Gallery = append(sc.Gallery, strings.Replace(imageURL, "https:", "http:", 1))
+		})
+
+		// Tags
+		e.ForEach(`.videoClip__Details__categoryTag`, func(id int, e *colly.HTMLElement) {
+			tag := strings.TrimSpace(e.Text)
+			sc.Tags = append(sc.Tags, tag)
+		})
+
+		// Synopsis
+		e.ForEach(`p[itemprop="description"]`, func(id int, e *colly.HTMLElement) {
+			reLeadcloseWhtsp := regexp.MustCompile(`^[\s\p{Zs}]+|[\s\p{Zs}]+$`)
+			reInsideWhtsp := regexp.MustCompile(`[\s\p{Zs}]{2,}`)
+			synopsis := reLeadcloseWhtsp.ReplaceAllString(e.Text, "")
+			synopsis = reInsideWhtsp.ReplaceAllString(synopsis, " ")
+			synopsis = strings.TrimSuffix(synopsis, " … Read more")
+			sc.Synopsis = synopsis
+		})
+
+		*out = append(*out, sc)
+	})
+
+	// Request scenes via REST API
+	r, err := resty.R().
+		SetHeader("User-Agent", userAgent).
+		SetHeader("content-type", "application/json;charset=UTF-8").
+		SetHeader("accept", "application/json, text/plain, */*").
+		SetHeader("referer", "https://realitylovers.com/videos").
+		SetHeader("origin", "https://realitylovers.com").
+		SetHeader("authority", "realitylovers.com").
+		SetBody(`{"searchQuery":"","categoryId":null,"perspective":null,"actorId":null,"offset":"5000","isInitialLoad":true,"sortBy":"NEWEST","videoView":"MEDIUM","device":"DESKTOP"}`).
+		Post("https://realitylovers.com/videos/search")
+	if err == nil || r.StatusCode() == 200 {
+		result := gjson.Get(r.String(), "contents")
+		result.ForEach(func(key, value gjson.Result) bool {
+			sceneURL := "https://realitylovers.com/" + value.Get("videoUri").String()
+			if !funk.ContainsString(knownScenes, sceneURL) {
+				ctx := colly.NewContext()
+				cover := strings.Fields(value.Get("mainImageSrcset").String())[0]
+				ctx.Put("cover", strings.Replace(cover, "https:", "http:", 1))
+				ctx.Put("id", value.Get("id").String())
+				ctx.Put("released", value.Get("released").String())
+				ctx.Put("title", value.Get("title").String())
+				sceneCollector.Request("GET", sceneURL, nil, ctx, nil)
+			}
+			return true
+		})
+	}
+
+	return nil
+}

--- a/pkg/scrape/realjamvr.go
+++ b/pkg/scrape/realjamvr.go
@@ -1,0 +1,156 @@
+package scrape
+
+import (
+	"log"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gocolly/colly"
+	"github.com/mozillazg/go-slugify"
+	"github.com/thoas/go-funk"
+)
+
+func ScrapeRealJamVR(knownScenes []string, out *[]ScrapedScene) error {
+	const maxRetries = 15
+
+	siteCollector := colly.NewCollector(
+		colly.AllowedDomains("realjamvr.com"),
+		colly.CacheDir(siteCacheDir),
+		colly.UserAgent(userAgent),
+	)
+
+	sceneCollector := colly.NewCollector(
+		colly.AllowedDomains("realjamvr.com"),
+		colly.CacheDir(sceneCacheDir),
+		colly.UserAgent(userAgent),
+	)
+
+	siteCollector.OnRequest(func(r *colly.Request) {
+		attempt := r.Ctx.GetAny("attempt")
+
+		if attempt == nil {
+			r.Ctx.Put("attempt", 1)
+		}
+
+		log.Println("visiting", r.URL.String())
+	})
+
+	sceneCollector.OnRequest(func(r *colly.Request) {
+		attempt := r.Ctx.GetAny("attempt")
+
+		if attempt == nil {
+			r.Ctx.Put("attempt", 1)
+		}
+
+		log.Println("visiting", r.URL.String())
+	})
+
+	siteCollector.OnError(func(r *colly.Response, err error) {
+		attempt := r.Ctx.GetAny("attempt").(int)
+
+		if r.StatusCode == 429 {
+			log.Println("Error:", r.StatusCode, err)
+
+			if attempt <= maxRetries {
+				unCache(r.Request.URL.String(), siteCollector.CacheDir)
+				log.Println("Waiting 2 seconds before next request...")
+				r.Ctx.Put("attempt", attempt+1)
+				time.Sleep(2 * time.Second)
+				r.Request.Retry()
+			}
+		}
+	})
+
+	sceneCollector.OnError(func(r *colly.Response, err error) {
+		attempt := r.Ctx.GetAny("attempt").(int)
+
+		if r.StatusCode == 429 {
+			log.Println("Error:", r.StatusCode, err)
+
+			if attempt <= maxRetries {
+				unCache(r.Request.URL.String(), sceneCollector.CacheDir)
+				log.Println("Waiting 2 seconds before next request...")
+				r.Ctx.Put("attempt", attempt+1)
+				time.Sleep(2 * time.Second)
+				r.Request.Retry()
+			}
+		}
+	})
+
+	sceneCollector.OnHTML(`html`, func(e *colly.HTMLElement) {
+		sc := ScrapedScene{}
+		sc.SceneType = "VR"
+		sc.Studio = "Real Jam Network"
+		sc.Site = "RealJam VR"
+		sc.HomepageURL = strings.Split(e.Request.URL.String(), "?")[0]
+
+		// Scene ID - get from URL
+		tmp := strings.Split(sc.HomepageURL, "/")
+		sc.SiteID = strings.Split(tmp[len(tmp)-1], "-")[0]
+		sc.SceneID = slugify.Slugify(sc.Site) + "-" + sc.SiteID
+
+		// Cast
+		e.ForEach(`.featuring a`, func(id int, e *colly.HTMLElement) {
+			sc.Cast = append(sc.Cast, strings.TrimSpace(e.Text))
+		})
+
+		// Duration
+		sc.Duration, _ = strconv.Atoi(strings.Split(strings.TrimSpace(e.ChildText(`.duration`)), ":")[0])
+
+		// Released
+		sc.Released = strings.TrimSuffix(strings.TrimSpace(e.ChildText(`.date`)), ",")
+
+		// Title, Cover URL
+		sc.Title = strings.TrimSpace(e.ChildAttr(`deo-video`, "title"))
+		sc.Covers = append(sc.Covers, strings.TrimSpace(e.ChildAttr(`deo-video`, "cover-image")))
+
+		// Gallery
+		e.ForEach(`.scene-previews-container a`, func(id int, e *colly.HTMLElement) {
+			sc.Gallery = append(sc.Gallery, strings.TrimSpace(e.Attr("href")))
+		})
+
+		// Synopsis
+		sc.Synopsis = strings.TrimSpace(e.ChildText(`div.desc`))
+
+		// Tags
+		e.ForEach(`div.tags a`, func(id int, e *colly.HTMLElement) {
+			sc.Tags = append(sc.Tags, strings.TrimSpace(e.Text))
+		})
+
+		// Filenames
+		set := make(map[string]struct{})
+		e.ForEach(`.downloads a`, func(id int, e *colly.HTMLElement) {
+			u, _ := url.Parse(e.Attr("href"))
+			q := u.Query()
+			r, _ := regexp.Compile("attachment; filename=\"(.*?)\"")
+			match := r.FindStringSubmatch(q.Get("response-content-disposition"))
+			if len(match) > 0 {
+				set[match[1]] = struct{}{}
+			}
+		})
+		for f := range set {
+			sc.Filenames = append(sc.Filenames, strings.ReplaceAll(f, " ", "_"))
+		}
+
+		*out = append(*out, sc)
+	})
+
+	siteCollector.OnHTML(`#pagination a`, func(e *colly.HTMLElement) {
+		pageURL := e.Request.AbsoluteURL(e.Attr("href"))
+		siteCollector.Visit(pageURL)
+	})
+
+	siteCollector.OnHTML(`div.movies-list a:not(.promo__info):not(#pagination a)`, func(e *colly.HTMLElement) {
+		sceneURL := e.Request.AbsoluteURL(e.Attr("href"))
+
+		// If scene exist in database, there's no need to scrape
+		if !funk.ContainsString(knownScenes, sceneURL) && !strings.Contains(sceneURL, "/join") {
+			sceneCollector.Visit(sceneURL)
+		}
+	})
+
+	return siteCollector.Visit("https://realjamvr.com/virtualreality/list")
+}

--- a/pkg/scrape/scrape.go
+++ b/pkg/scrape/scrape.go
@@ -1,7 +1,11 @@
 package scrape
 
 import (
+	"crypto/sha1"
+	"encoding/hex"
+	"log"
 	"os"
+	"path"
 	"path/filepath"
 
 	"github.com/ProtonMail/go-appdir"
@@ -31,6 +35,16 @@ type ScrapedScene struct {
 	Synopsis    string   `json:"synopsis"`
 	Released    string   `json:"released"`
 	HomepageURL string   `json:"homepage_url"`
+}
+
+func unCache(URL string, cacheDir string) {
+	sum := sha1.Sum([]byte(URL))
+	hash := hex.EncodeToString(sum[:])
+	dir := path.Join(cacheDir, hash[:2])
+	filename := path.Join(dir, hash)
+	if err := os.Remove(filename); err != nil {
+		log.Fatal(err)
+	}
 }
 
 func init() {

--- a/pkg/xbvr/task_content.go
+++ b/pkg/xbvr/task_content.go
@@ -97,6 +97,9 @@ func Scrape() {
 		tlog.Infof("Scraping RealityLovers")
 		scrape.ScrapeRealityLovers(knownScenes, &collectedScenes)
 
+		tlog.Infof("Scraping RealJam VR")
+		scrape.ScrapeRealJamVR(knownScenes, &collectedScenes)
+
 		if len(collectedScenes) > 0 {
 			tlog.Infof("Scraped %v new scenes", len(collectedScenes))
 
@@ -183,6 +186,7 @@ func ExportBundle() {
 		scrape.ScrapeHoloGirlsVR(knownScenes, &collectedScenes)
 		scrape.ScrapeLethalHardcoreVR(knownScenes, &collectedScenes)
 		scrape.ScrapeRealityLovers(knownScenes, &collectedScenes)
+		scrape.ScrapeRealJamVR(knownScenes, &collectedScenes)
 
 		out := ContentBundle{
 			Timestamp:     time.Now().UTC(),

--- a/pkg/xbvr/task_content.go
+++ b/pkg/xbvr/task_content.go
@@ -87,13 +87,16 @@ func Scrape() {
 
 		tlog.Infof("Scraping VRLatina")
 		scrape.ScrapeVRLatina(knownScenes, &collectedScenes)
-		
+
 		tlog.Infof("Scraping HoloGirlsVR")
-                scrape.ScrapeHoloGirlsVR(knownScenes, &collectedScenes)
+		scrape.ScrapeHoloGirlsVR(knownScenes, &collectedScenes)
 
 		tlog.Infof("Scraping LethalHardcoreVR / WhorecraftVR")
-                scrape.ScrapeLethalHardcoreVR(knownScenes, &collectedScenes)
-		
+		scrape.ScrapeLethalHardcoreVR(knownScenes, &collectedScenes)
+
+		tlog.Infof("Scraping RealityLovers")
+		scrape.ScrapeRealityLovers(knownScenes, &collectedScenes)
+
 		if len(collectedScenes) > 0 {
 			tlog.Infof("Scraped %v new scenes", len(collectedScenes))
 
@@ -177,6 +180,9 @@ func ExportBundle() {
 		scrape.ScrapeTmwVRnet(knownScenes, &collectedScenes)
 		scrape.ScrapeDDFNetworkVR(knownScenes, &collectedScenes)
 		scrape.ScrapeVRLatina(knownScenes, &collectedScenes)
+		scrape.ScrapeHoloGirlsVR(knownScenes, &collectedScenes)
+		scrape.ScrapeLethalHardcoreVR(knownScenes, &collectedScenes)
+		scrape.ScrapeRealityLovers(knownScenes, &collectedScenes)
 
 		out := ContentBundle{
 			Timestamp:     time.Now().UTC(),


### PR DESCRIPTION
Fixed the commit history!

Now with better retry logic (no more endless retries) and cache invalidation since colly caches the error responses... which seems weird but there was no traction on this issue:

https://github.com/gocolly/colly/issues/189

I was able to scrape the site multiple times with the retries kicking in and the cache enabled.